### PR TITLE
Potential fix for code scanning alert no. 53: Code injection

### DIFF
--- a/routes/trackOrder.ts
+++ b/routes/trackOrder.ts
@@ -15,7 +15,7 @@ export function trackOrder () {
     const id = !utils.isChallengeEnabled(challenges.reflectedXssChallenge) ? String(req.params.id).replace(/[^\w-]+/g, '') : utils.trunc(req.params.id, 60)
 
     challengeUtils.solveIf(challenges.reflectedXssChallenge, () => { return utils.contains(id, '<iframe src="javascript:alert(`xss`)">') })
-    db.ordersCollection.find({ $where: `this.orderId === '${id}'` }).then((order: any) => {
+    db.ordersCollection.find({ orderId: id }).then((order: any) => {
       const result = utils.queryResultToJson(order)
       challengeUtils.solveIf(challenges.noSqlOrdersChallenge, () => { return result.data.length > 1 })
       if (result.data[0] === undefined) {


### PR DESCRIPTION
Potential fix for [https://github.com/bruno-barbosa978/juice-shop-ada-1466/security/code-scanning/53](https://github.com/bruno-barbosa978/juice-shop-ada-1466/security/code-scanning/53)

To eliminate code injection risk, user input should never be executed as code on the database. The correct MongoDB query for finding documents by `orderId` should use a direct query object: `{ orderId: id }`, rather than a string of JavaScript run via `$where`. Thus, replace the `$where` operator and the JavaScript string with a proper query object using the sanitized `id`. This can be achieved by rewriting

```js
db.ordersCollection.find({ $where: `this.orderId === '${id}'` })
```

as

```js
db.ordersCollection.find({ orderId: id })
```

No additional sanitization or escaping is required with this approach, and MongoDB will perform an exact match against the `orderId` field. The change should be made on line 18 in `routes/trackOrder.ts`. No new imports or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
